### PR TITLE
FIX - override ngModel.$isEmpty to work as in input type checkbox.

### DIFF
--- a/angular-icheck.js
+++ b/angular-icheck.js
@@ -14,15 +14,21 @@ angular.module('angular-icheck', [])
                 ele.bind("click", function () {
                     box.toggleClass("checked");
                     ctrl.$setViewValue(box.hasClass("checked"));
-
                 });
                 ctrl.$render = function () {
                     if (ctrl.$viewValue) {
                         box.addClass("checked");
-                    }else{
+                    } else {
                         box.removeClass("checked");
                     }
                 };
+                // https://github.com/angular/angular.js/issues/2594
+                // override $isEmpty method
+                ctrl.$isEmpty = function(value) {
+                    return value === false;
+                };
+                ctrl.$setViewValue(box.hasClass("checked"));
+                ctrl.$validate();
             }
         }
     }]);

--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,6 @@
     "tests"
   ],
   "dependencies": {
-    "angularjs": "~1.3.15"
+    "angular": "~1.4.1"
   }
 }

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 <body ng-init="male=true">
 <i-check ng-model="male">男</i-check>
 {{male}}
-<script src="bower_components/angularjs/angular.js"></script>
+<script src="bower_components/angular/angular.js"></script>
 <script src="angular-icheck.js"></script>
 <script>
     angular.module('app',[


### PR DESCRIPTION
https://github.com/angular/angular.js/issues/2594

I've got the same issue.
